### PR TITLE
Enhance configuration sync and validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,12 @@
         "OpenShift-Local.memory": {
           "type": "number",
           "format": "memory",
-          "minimum": 8192,
-          "default": 9216,
           "description": "Memory size in MiB (must be greater than or equal to '2048')"
         },
         "OpenShift-Local.cpus": {
           "type": "number",
           "format": "cpu",
-          "minimum": 4,
-          "default": 4,
-          "description": "Number of CPU cores (must be greater than or equal to '4')"
+          "description": "Number of CPU cores"
         },
         "OpenShift-Local.preset": {
           "type": "string",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Preset } from './daemon-commander';
+
+// copied from https://github.com/crc-org/crc/blob/632676d7c9ba0c030736c3d914984c4e140c1bf5/pkg/crc/constants/constants.go#L198
+
+export function getDefaultCPUs(preset: Preset): number {
+  switch (preset) {
+    case 'openshift':
+      return 4;
+    case 'microshift':
+    case 'podman':
+      return 2;
+    default:
+      // should not be reached
+      return 4;
+  }
+}
+
+export function getDefaultMemory(preset: Preset): number {
+  switch (preset) {
+    case 'openshift':
+      return 9216;
+    case 'microshift':
+      return 4096;
+    case 'podman':
+      return 2048;
+    default:
+      // should not be reached
+      return 9216;
+  }
+}

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -48,6 +48,17 @@ export interface Configuration {
   [key: string]: string | number;
 }
 
+export type ConfigKeys =
+  | 'cpus'
+  | 'memory'
+  | 'disk-size'
+  | 'consent-telemetry'
+  | 'http-proxy'
+  | 'https-proxy'
+  | 'no-proxy'
+  | 'proxy-ca-file'
+  | 'pull-secret-file';
+
 export class DaemonCommander {
   private apiPath: string;
 
@@ -121,6 +132,19 @@ export class DaemonCommander {
     const url = this.apiPath + '/config';
 
     const result = await got.post(url, {
+      json: { properties: values },
+      throwHttpErrors: false,
+      // body: values,
+    });
+    if (result.statusCode !== 200) {
+      throw new Error(result.body);
+    }
+  }
+
+  async configUnset(values: ConfigKeys[]): Promise<void> {
+    const url = this.apiPath + '/config';
+
+    const result = await got.delete(url, {
       json: { properties: values },
       throwHttpErrors: false,
       // body: values,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type * as extensionApi from '@podman-desktop/api';
+
+export const defaultLogger: extensionApi.Logger = {
+  error: () => {
+    // ignore
+  },
+  log: () => {
+    // ignore
+  },
+  warn: () => {
+    // ignore
+  },
+};


### PR DESCRIPTION
This PR remove default and minimum values from crc-extension configuration.
Add validation of configuration property based on current preset.
Also it inform and assist user recreate instance when preset changed.
And PR add proxy setting sync, but in case of proxy settings we copy setting from podman-desktop to crc.

Resolves https://github.com/crc-org/crc-extension/issues/32

Demo:

https://user-images.githubusercontent.com/929743/229790494-b87f9224-e4f4-4bef-812f-05128f50c62a.mov

