### PR TITLE
Add vscode launch config to debug extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Podman-Desktop Process",
+            "skipFiles": ["<node_internals>/**"],
+            "program": "${workspaceFolder}/scripts/run.mjs",
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/**",
+                "!**/node_modules/**"
+            ],
+            "sourceMaps": true,
+            "args": ["debug"],
+            "autoAttachChildProcesses": true
+        },
+        {
+            // Needs to start "Debug Podman-Desktop Process" first
+            "name": "Attach Debugger to Main Process",
+            "request": "attach",
+            "type": "node",
+            "port": 9223,
+            "sourceMaps": true,
+            "timeout": 30000
+        },
+    ],
+}
+

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -100,6 +100,11 @@ async function run() {
   await exec('yarn', ['watch'], {cwd:  desktopPath});
 }
 
+async function debug() {
+  exec('yarn', ['watch'], {cwd: path.join(__dirname, '..')});
+  await exec('yarn', ['watch', '--extension-folder', path.join(__dirname, '..')], {cwd:  desktopPath});
+}
+
 const firstArg = process.argv[2];
 
 switch(firstArg) {
@@ -109,6 +114,9 @@ switch(firstArg) {
 
   case 'run':
     await run();
+    break;
+  case 'debug':
+    await debug();
     break;
 
   case 'prepare' :


### PR DESCRIPTION
Just use `Debug Podman-Desktop Process` to launch podman desktop with crc-extenson.

If you use this, meke sure to delete `<home>/.local/share/containers/podman-desktop/plugins/openshift-local` folder.