### PR TITLE
Propose to initialise if setup not finished

### DIFF
--- a/src/crc-status.ts
+++ b/src/crc-status.ts
@@ -19,8 +19,10 @@
 import * as extensionApi from '@podman-desktop/api';
 import type { Status, CrcStatus as CrcStatusApi } from './daemon-commander';
 import { commander } from './daemon-commander';
+import { isNeedSetup } from './crc-setup';
 
 const defaultStatus: Status = { CrcStatus: 'Unknown', Preset: 'Unknown' };
+const setupStatus: Status = { CrcStatus: 'Need Setup', Preset: 'Unknown' };
 const errorStatus: Status = { CrcStatus: 'Error', Preset: 'Unknown' };
 
 export class CrcStatus {
@@ -73,6 +75,11 @@ export class CrcStatus {
   }
 
   async initialize(): Promise<void> {
+    if (isNeedSetup) {
+      this._status = setupStatus;
+      return;
+    }
+
     try {
       // initial status
       this._status = await commander.status();
@@ -121,6 +128,8 @@ export class CrcStatus {
         return 'stopped';
       case 'Error':
         return 'error';
+      case 'Need Setup':
+        return 'installed';
       default:
         return 'not-installed';
     }

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -20,7 +20,15 @@ import type { Response } from 'got';
 import got from 'got';
 import { isWindows } from './util';
 
-export type CrcStatus = 'Running' | 'Starting' | 'Stopping' | 'Stopped' | 'No Cluster' | 'Error' | 'Unknown';
+export type CrcStatus =
+  | 'Running'
+  | 'Starting'
+  | 'Stopping'
+  | 'Stopped'
+  | 'No Cluster'
+  | 'Error'
+  | 'Unknown'
+  | 'Need Setup';
 
 export interface Status {
   readonly CrcStatus: CrcStatus;

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -50,22 +50,26 @@ interface ConfigEntry {
 let initialCrcConfig: Configuration;
 
 export async function syncPreferences(context: extensionApi.ExtensionContext): Promise<void> {
-  initialCrcConfig = await commander.configGet();
+  try {
+    initialCrcConfig = await commander.configGet();
 
-  const extConfig = extensionApi.configuration.getConfiguration();
+    const extConfig = extensionApi.configuration.getConfiguration();
 
-  for (const key in configMap) {
-    const element = configMap[key];
-    await extConfig.update(key, initialCrcConfig[element.name]);
+    for (const key in configMap) {
+      const element = configMap[key];
+      await extConfig.update(key, initialCrcConfig[element.name]);
+    }
+
+    context.subscriptions.push(
+      extensionApi.configuration.onDidChangeConfiguration(e => {
+        configChanged(e);
+      }),
+    );
+
+    syncProxy(context);
+  } catch (err) {
+    console.error('Cannot sync preferences: ', err);
   }
-
-  context.subscriptions.push(
-    extensionApi.configuration.onDidChangeConfiguration(e => {
-      configChanged(e);
-    }),
-  );
-
-  syncProxy(context);
 }
 
 async function syncProxy(context: extensionApi.ExtensionContext): Promise<void> {


### PR DESCRIPTION
This PR add check for `crc setup` state, and if crc requires to call `setup`, it propose to do that with `initialise` button on dashboard.

Related issue https://github.com/crc-org/crc-extension/issues/39

Demo:


https://user-images.githubusercontent.com/929743/233959694-8f339b94-46fc-4d7d-ade0-b8f3e1a6cc22.mp4

