### PR TITLE
Allow `oc-env` to be used with the `microshift` preset

### DIFF
--- a/src/dev-terminal.ts
+++ b/src/dev-terminal.ts
@@ -44,6 +44,7 @@ async function openTerminalWithOC(): Promise<void> {
 
   switch (crcStatus.status.Preset) {
     case 'openshift':
+    case 'microshift':
       command = 'oc-env';
       break;
     case 'podman':


### PR DESCRIPTION
For the `microshift` preset it is preferred to use the `oc` command to interact with the API. We missed adding this check to match the OpenShift usage.