### PR TITLE
Make sure the publisher name is consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM scratch
 
 LABEL org.opencontainers.image.title="OpenShift Local" \
         org.opencontainers.image.description="Allows the ability to start and stop OpenShift Local and use Podman Desktop to interact with it" \
-        org.opencontainers.image.vendor="podman-desktop" \
+        org.opencontainers.image.vendor="crc-org" \
         io.podman-desktop.api.version=">= 0.12.0"
 
 COPY package.json /extension/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This extension provides a Red Hat OpenShift Local cluster and allows Podman Desktop to interact with it",
   "version": "0.0.1",
   "icon": "icon.png",
-  "publisher": "crc-team",
+  "publisher": "crc-org",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"


### PR DESCRIPTION
Aligned the publisher/vendor name of the extension container and the package identifier are referencing the same