### PR TITLE
add 'configured' state

### DIFF
--- a/src/crc-status.ts
+++ b/src/crc-status.ts
@@ -123,9 +123,9 @@ export class CrcStatus {
       case 'Stopping':
         return 'stopping';
       case 'Stopped':
-        return 'stopped';
+        return 'configured';
       case 'No Cluster':
-        return 'stopped';
+        return 'configured';
       case 'Error':
         return 'error';
       case 'Need Setup':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         if (hasSetupFinished) {
           await needSetup();
           connectToCrc();
+          presetChanged(provider, extensionContext);
         }
       },
     }),
@@ -198,7 +199,7 @@ async function registerOpenShiftLocalCluster(
 async function readPreset(crcStatus: Status): Promise<'Podman' | 'OpenShift' | 'MicroShift' | 'unknown'> {
   let preset: string;
   //preset could be undefined if vm not created yet, use preferences instead
-  if (crcStatus.Preset === undefined) {
+  if (crcStatus.Preset === undefined || crcStatus.Preset === 'Unknown') {
     const config = await commander.configGet();
     preset = config.preset;
   } else {


### PR DESCRIPTION
This PR add `configured` state for provider, which allow to start crc from dashboard:
<img width="1052" alt="Screenshot 2023-05-02 at 17 02 28" src="https://user-images.githubusercontent.com/929743/235689871-c0af26aa-d58a-440b-838e-22e784b616b9.png">



Fix https://github.com/crc-org/crc-extension/issues/64

Depends on https://github.com/containers/podman-desktop/pull/2304