### PR TITLE
Configuration sync fix and start/stop status enhance

### DIFF
--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -67,6 +67,22 @@ export type ConfigKeys =
   | 'proxy-ca-file'
   | 'pull-secret-file';
 
+export interface ClusterConfig {
+  ClusterType: string;
+  ClusterCACert: string;
+  KubeConfig: string;
+  KubeAdminPass: string;
+  ClusterAPI: string;
+  WebConsoleURL: string;
+  ProxyConfig: unknown;
+}
+
+export interface StartInfo {
+  Status: CrcStatus;
+  ClusterConfig: ClusterConfig;
+  KubeletStarted: boolean;
+}
+
 export class DaemonCommander {
   private apiPath: string;
 
@@ -105,7 +121,7 @@ export class DaemonCommander {
     return JSON.parse(body);
   }
 
-  async start() {
+  async start(): Promise<StartInfo> {
     const url = this.apiPath + '/start';
     const response = await this.get(url);
 


### PR DESCRIPTION

Resolve https://github.com/crc-org/crc-extension/issues/78
Resolve https://github.com/crc-org/crc-extension/issues/82

In general PR speed up dashboard status change during start/stop by using `provider.updateStatus` method.

Demo:

https://user-images.githubusercontent.com/929743/236789706-6fa5d483-0e1d-4e05-9a37-efce1fbb661e.mov

https://user-images.githubusercontent.com/929743/236789685-e6359574-7165-495a-ab18-213cd33711f2.mov




