### PR TITLE
Fixes #67 Shows infoDialog when podman preset is used

### DIFF
--- a/src/crc-setup.ts
+++ b/src/crc-setup.ts
@@ -48,7 +48,7 @@ export async function setUpCrc(logger: extensionApi.Logger, askForPreset = false
       });
     } else {
       let choice = preset.toLowerCase();
-      if(choice.includes('microshift')) {
+      if (choice.includes('microshift')) {
         choice = 'microshift';
       }
       await execPromise(getCrcCli(), ['config', 'set', 'preset', choice]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -287,6 +287,12 @@ async function presetChanged(
   // detect preset of CRC
   const preset = await readPreset(crcStatus.status);
   if (preset === 'Podman') {
+    // do nothing
+    extensionApi.window.showInformationMessage(
+      'Currently we do not support the Podman preset of OpenShift Local. Please use preference to change this:\n\nSettings > Preferences > Red Hat OpenShift Local > Preset',
+      'OK',
+    );
+
     // podman connection
     registerPodmanConnection(provider, extensionContext);
   } else if (preset === 'OpenShift') {


### PR DESCRIPTION
Fixes #67 

Currently we do not support the podman preset, 'focus' on OpenShift and MicroShift, as decided at the F2F. This means we need to tell the user we would have to change the preset to work correctly. The current text is temporary until we have a better solution, like markdown formatted or decided to implement support.