### PR TITLE
Fixes #56 Alternative pull-secret info dialog

### DIFF
--- a/src/crc-setup.ts
+++ b/src/crc-setup.ts
@@ -48,7 +48,7 @@ export async function setUpCrc(logger: extensionApi.Logger, askForPreset = false
       });
     } else {
       let choice = preset.toLowerCase();
-      if(choice.includes('microshift')) {
+      if (choice.includes('microshift')) {
         choice = 'microshift';
       }
       await execPromise(getCrcCli(), ['config', 'set', 'preset', choice]);

--- a/src/crc-start.ts
+++ b/src/crc-start.ts
@@ -88,6 +88,12 @@ export async function startCrc(
 }
 
 async function askAndStorePullSecret(logger: extensionApi.Logger): Promise<boolean> {
+  extensionApi.window.showInformationMessage(
+    `To pull container images from the registry, a pull secret is necessary. You can get a pull secret from the Red Hat OpenShift Local download page by navigating to the dashboard and clicking the "Obtain pull-secret" or opening the following address in your browser https://cloud.redhat.com/openshift/create/local
+    Use the "Copy pull secret" option and paste the content. You need to provide this in the input prompt shown after clicking "Continue".`,
+    'Continue',
+  );
+
   const pullSecret = await extensionApi.window.showInputBox({
     prompt: 'Provide a pull secret',
     // prompt: 'To pull container images from the registry, a pull secret is necessary.',


### PR DESCRIPTION
Temporary solution to add an informational dialog before the pull-secret input.

![image](https://github.com/crc-org/crc-extension/assets/1894/4835408c-5f27-4e56-994e-d1d3a5bbd47a)
