### PR TITLE
Minor update to container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ To pull container images from the registry, a pull secret is necessary. You can 
 
 ## Installation
 From the Podman Desktop interface, go to the Settings tab and click on "Desktop Extensions".
-As name fill in: `quay.io/redhat-developer/openshift-local-extension:latest` and click on the "Install extension" button.
+As name fill in: 
+
+```
+quay.io/redhat-developer/openshift-local-extension:latest
+```
+
+and click on the "Install extension" button.
 
 
 ## Features


### PR DESCRIPTION
Depending on how this is rendered, like on GitHub, a copy to clipboard button is shown.

![image](https://github.com/crc-org/crc-extension/assets/1894/3d5b750b-331c-41d5-8c5b-2773bf1fc08c)
