### PR TITLE
Use custom path for podman cli call

### DIFF
--- a/src/podman-cli.ts
+++ b/src/podman-cli.ts
@@ -17,7 +17,9 @@
  ***********************************************************************/
 
 import { configuration } from '@podman-desktop/api';
-import { isWindows } from './util';
+import { isMac, isWindows } from './util';
+
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
 export function getPodmanCli(): string {
   // If we have a custom binary path regardless if we are running Windows or not
@@ -36,4 +38,19 @@ export function getPodmanCli(): string {
 // return string or undefined
 export function getCustomBinaryPath(): string | undefined {
   return configuration.getConfiguration('podman').get('binary.path');
+}
+
+export function getPodmanInstallationPath(): string {
+  const env = process.env;
+  if (isWindows()) {
+    return `c:\\Program Files\\RedHat\\Podman;${env.PATH}`;
+  } else if (isMac()) {
+    if (!env.PATH) {
+      return macosExtraPath;
+    } else {
+      return env.PATH.concat(':').concat(macosExtraPath);
+    }
+  } else {
+    return env.PATH;
+  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,11 +43,19 @@ export interface SpawnResult {
   stdErr: string;
 }
 
-export function runCliCommand(command: string, args: string[]): Promise<SpawnResult> {
+export interface RunOptions {
+  env: NodeJS.ProcessEnv | undefined;
+}
+
+export function runCliCommand(command: string, args: string[], options?: RunOptions): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
     let output = '';
     let err = '';
-    const env = Object.assign({}, process.env);
+    let env = Object.assign({}, process.env);
+
+    if (options?.env) {
+      env = Object.assign(env, options.env);
+    }
 
     if (isWindows()) {
       // Escape any whitespaces in command


### PR DESCRIPTION
This PR fix call for podman cli from release version of podman-desktop. 
Electron apps in release don’t use shell env path variable, so for podman cli we use custom path env variable(copied from podman extension)