### PR TITLE
build: add .dockerignore to skip copying node_modules and dist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
if these two directories are copied to the build container, i got the following errors while using `podman-remote` to build:

```
[!] Error: EACCES: permission denied, open '/opt/app-root/src/dist/extension.js'
Error: EACCES: permission denied, open '/opt/app-root/src/dist/extension.js'
```

```
[3/5] Fetching packages...
error An unexpected error occurred: "EACCES: permission denied, unlink '/opt/app-root/src/node_modules/.yarn-integrity'".
info If you think this is a bug, please open a bug report with the information provided in "/opt/app-root/src/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: building at STEP "RUN npm install -g yarn     && npx yarn install     && npx yarn build": while running runtime: exit status 1
```