### PR TITLE
Update installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ To pull container images from the registry, a pull secret is necessary. You can 
 
 
 ## Installation
-From the Podman Desktop interface, go to the Settings tab and click on "Desktop Extensions".
-As name fill in: 
 
-```
-quay.io/redhat-developer/openshift-local-extension:latest
-```
+1. Open Podman Desktop dashboard.
+1. Go to the **Settings > Extensions > Install a new extension from OCI Image**.
+1. **Name of the image**: Enter
 
-and click on the "Install extension" button.
+   ```
+   quay.io/redhat-developer/openshift-local-extension:latest
+   ```
+
+1. Click on the **Install extension from the OCI image** button.
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ To pull container images from the registry, a pull secret is necessary. You can 
 
 ## Installation
 
+#### Prerequisites
+
+* The extension is not already installed.
+
+#### Procedure
+
 1. Open Podman Desktop dashboard.
 1. Go to the **Settings > Extensions > Install a new extension from OCI Image**.
 1. **Name of the image**: Enter


### PR DESCRIPTION
Updated the location of the installation field to **Settings > Extensions**.

![Screenshot from 2023-05-25 11:04:47 Podman Desktop 1920x1032 01](https://github.com/crc-org/crc-extension/assets/243761/471fcc51-54ce-47c2-a9b8-e7f579ebc9dd)


The location **Settings > Destkop Extensions** was leading to installation error: Image `quay.io/redhat-developer/openshift-local-extension:latest is not a Docker Desktop Extension`


![Screenshot from 2023-05-25 11:02:31 Podman Desktop 1920x1032 01](https://github.com/crc-org/crc-extension/assets/243761/d19a2ac8-591a-4e77-9fa7-47b873f19f24)

