### PR TITLE
Start Windows CRC executable path with upper case drive-letter

### DIFF
--- a/src/crc-cli.ts
+++ b/src/crc-cli.ts
@@ -23,7 +23,7 @@ import type { Logger } from '@podman-desktop/api';
 import type { Preset } from './types';
 
 const macosExtraPath = '/usr/local/bin:/opt/local/bin';
-const crcWindowsInstallPath = 'c:\\Program Files\\Red Hat OpenShift Local';
+const crcWindowsInstallPath = 'C:\\Program Files\\Red Hat OpenShift Local';
 
 export function getInstallationPath(): string {
   const env = process.env;


### PR DESCRIPTION
Due to a strict check of a `hidden_daemon.ps1` file content during `crc setup` on `crc` side there is an error when initializing the CRC in podman desktop. This PR should align the default windows `crc` executable location with this strict check.

Fixes #175 