### PR TITLE
fix: delay crc-detection and init till after activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ let connectionFactoryDisposable: extensionApi.Disposable;
 
 let crcVersion: CrcVersion | undefined;
 
-export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
+async function _activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   const crcInstaller = new CrcInstall(extensionContext.storagePath);
 
   crcVersion = await getCrcVersion();
@@ -188,6 +188,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       updateProviderVersionWithPreset(provider, e.Preset as Preset);
     }),
   );
+}
+
+export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
+  _activate(extensionContext).catch(console.error);
 }
 
 async function registerCrcUpdate(


### PR DESCRIPTION
Fix #211.

```
main ↪️ Activating extension (redhat.openshift-local) with max activation time of 20 seconds
VM5:62 main ↪️ Activating extension (redhat.openshift-local) ended in 11 milliseconds
```