### PR TITLE
fix: set correct minimum memory values in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
         "crc.factory.openshift.memory": {
           "type": "number",
           "format": "memory",
-          "minimum": 11000000000,
-          "default": 11000000000,
+          "minimum": 11274289152,
+          "default": 11274289152,
           "maximum": "HOST_TOTAL_MEMORY",
           "step": 500000000,
           "description": "Memory size",
@@ -33,8 +33,8 @@
         "crc.factory.microshift.memory": {
           "type": "number",
           "format": "memory",
-          "minimum": 4000000000,
-          "default": 4000000000,
+          "minimum": 4294967296,
+          "default": 4294967296,
           "maximum": "HOST_TOTAL_MEMORY",
           "step": 500000000,
           "description": "Memory size",
@@ -85,7 +85,7 @@
         "crc.factory.disksize": {
           "type": "number",
           "format": "diskSize",
-          "minimum": 35000000000,
+          "minimum": 37580963840,
           "maximum": "HOST_TOTAL_DISKSIZE",
           "step": 500000000,
           "description": "Disk size",


### PR DESCRIPTION
The values that are within the package.json are the ones that are used by podman desktop to generate the range of the sliders. Because the max value is in bytes, we also have to use bytes for the minimum.
However CRC expects bits values. So the minimum memory value accepted by CRC for microshift is 4096 MiB converted to bytes 4294967296.
Same calculation has been made for the rest.

This is somehow part of https://github.com/crc-org/crc-extension/issues/243 bc with the current values you could set an invalid memory amount. The minimum was  4000000000 bytes that converted to Mib are 3814, which is less than the minimum accepted 4096