### PR TITLE
fix: handle error so that it is shown in both page and task manager

### DIFF
--- a/src/crc-setup.ts
+++ b/src/crc-setup.ts
@@ -25,12 +25,13 @@ export async function needSetup(): Promise<boolean> {
     await execPromise(getCrcCli(), ['setup', '--check-only']);
     return false;
   } catch (e) {
+    console.log(e)
     return true;
   }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function setUpCrc(logger: extensionApi.Logger, askForPreset = false): Promise<boolean> {
+export async function setUpCrc(askForPreset = false): Promise<boolean> {
   if (askForPreset) {
     const preset = await extensionApi.window.showInformationMessage(
       'Which preset bundle would you like to use with OpenShift Local. MicroShift, provides a lightweight and optimized environment with a limited set of services. OpenShift, provides a single node OpenShift cluster with a fuller set of services, including a web console (requires more resources).',

--- a/src/crc-start.ts
+++ b/src/crc-start.ts
@@ -37,7 +37,7 @@ const missingPullSecret = 'Failed to ask for pull secret';
 
 export async function startCrc(
   provider: extensionApi.Provider,
-  logger: extensionApi.Logger,
+  loggerCallback: (data: string) => void,
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<boolean> {
   telemetryLogger.logUsage('crc.start', {
@@ -49,16 +49,15 @@ export async function startCrc(
     if (isNeedSetup) {
       try {
         crcStatus.setSetupRunning(true);
-        await setUpCrc(logger);
+        await setUpCrc();
       } catch (error) {
-        logger.error(error);
         provider.updateStatus('stopped');
-        return;
+        throw error;
       } finally {
         crcStatus.setSetupRunning(false);
       }
     }
-    crcLogProvider.startSendingLogs(logger);
+    crcLogProvider.startSendingLogs(loggerCallback);
     const result = await commander.start();
     if (result.Status === 'Running') {
       provider.updateStatus('started');
@@ -72,11 +71,11 @@ export async function startCrc(
       // check that crc missing pull secret
       if (err.message.startsWith(missingPullSecret)) {
         // ask user to provide pull secret
-        if (await askAndStorePullSecret(logger)) {
+        if (await askAndStorePullSecret()) {
           // if pull secret provided try to start again
-          return startCrc(provider, logger, telemetryLogger);
+          return startCrc(provider, loggerCallback, telemetryLogger);
         } else {
-          throw new Error('Could not start without pullsecret!');
+          throw new Error(`${productName} start error: VM cannot be started without the pullsecret`);
         }
       } else if (err.name === 'RequestError' && err.code === 'ECONNRESET') {
         // look like crc start normally, but we receive empty response from socket, so 'got' generate an error
@@ -84,14 +83,14 @@ export async function startCrc(
         return true;
       }
     }
-    extensionApi.window.showErrorMessage(`${productName} start error: ${err}`);
-    console.error(err);
+    console.error(err);    
     provider.updateStatus('stopped');
+    throw new Error(`${productName} start error: ${err}`);
   }
   return false;
 }
 
-async function askAndStorePullSecret(logger: extensionApi.Logger): Promise<boolean> {
+async function askAndStorePullSecret(): Promise<boolean> {
   let pullSecret: string;
   const authSession: extensionApi.AuthenticationSession | undefined = await extensionApi.authentication.getSession(
     'redhat.authentication-provider',
@@ -145,7 +144,6 @@ async function askAndStorePullSecret(logger: extensionApi.Logger): Promise<boole
     return true;
   } catch (error) {
     console.error(error);
-    logger.error(error);
   }
   return false;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import { commander, isDaemonRunning } from './daemon-commander';
-import { defaultPreset, getPresetLabel, isWindows, productName, providerId } from './util';
+import { defaultPreset, getLoggerCallback, getPresetLabel, isWindows, productName, providerId } from './util';
 import type { CrcVersion } from './crc-cli';
 import { getPreset } from './crc-cli';
 import { getCrcVersion } from './crc-cli';
@@ -250,39 +250,15 @@ async function createCrcVm(
   logger: extensionApi.Logger,
 ): Promise<void> {
   // we already have an instance
-  if (crcStatus.status.CrcStatus !== 'No Cluster' && !isNeedSetup()) {
+  if (crcStatus.status.CrcStatus !== 'No Cluster') {
     return;
   }
 
-  if (!isNeedSetup()) {
-    const initResult = await initializeCrc(provider, extensionContext, telemetryLogger, logger);
-    if (!initResult) {
-      throw new Error(`${productName} not initialized.`);
-    }
-  }
-
-  const hasStarted = await startCrc(provider, logger, telemetryLogger);
+  const hasStarted = await startCrc(provider, getLoggerCallback(undefined, logger), telemetryLogger);
   if (!connectionDisposable && hasStarted) {
     addCommands(telemetryLogger);
     presetChanged(provider, extensionContext, telemetryLogger);
   }
-}
-
-async function initializeCrc(
-  provider: extensionApi.Provider,
-  extensionContext: extensionApi.ExtensionContext,
-  telemetryLogger: extensionApi.TelemetryLogger,
-  logger: extensionApi.Logger,
-): Promise<boolean> {
-  const hasSetupFinished = await setUpCrc(logger, true);
-  if (hasSetupFinished) {
-    await needSetup();
-    await connectToCrc();
-    presetChanged(provider, extensionContext, telemetryLogger);
-    addCommands(telemetryLogger);
-    syncPreferences(provider, extensionContext, telemetryLogger);
-  }
-  return hasSetupFinished;
 }
 
 function addCommands(telemetryLogger: extensionApi.TelemetryLogger): void {
@@ -355,9 +331,14 @@ async function registerOpenShiftLocalCluster(
     delete: () => {
       return handleDelete(provider, extensionContext, telemetryLogger);
     },
-    start: async ctx => {
+    start: async (ctx, logger) => {
       provider.updateStatus('starting');
-      await startCrc(provider, ctx.log, telemetryLogger);
+      try {
+        await startCrc(provider, getLoggerCallback(ctx, logger,), telemetryLogger);
+      } catch (e) {
+        logger?.error(e);
+        throw e;
+      }      
     },
     stop: () => {
       provider.updateStatus('stopping');

--- a/src/install/crc-install.ts
+++ b/src/install/crc-install.ts
@@ -136,7 +136,7 @@ export class CrcInstall {
         provider.updateVersion(newInstalledCrc.version);
         let setupResult = false;
         if (await needSetup()) {
-          setupResult = await setUpCrc(logger, true);
+          setupResult = await setUpCrc(true);
         }
         installFinishedFn(setupResult, newInstalledCrc);
       }

--- a/src/log-provider.ts
+++ b/src/log-provider.ts
@@ -24,14 +24,14 @@ export class LogProvider {
   private timeout: NodeJS.Timeout;
   constructor(private readonly commander: DaemonCommander) {}
 
-  async startSendingLogs(logger: Logger): Promise<void> {
+  async startSendingLogs(loggerCallback: (data: string) => void): Promise<void> {
     let lastLogLine = 0;
     this.timeout = setInterval(async () => {
       try {
         const logs = await this.commander.logs();
         const logsDiff: string[] = logs.Messages.slice(lastLogLine, logs.Messages.length - 1);
         lastLogLine = logs.Messages.length;
-        logger.log(logsDiff.join('\n'));
+        loggerCallback(logsDiff.join('\n'));
       } catch (e) {
         console.log('Logs tick: ' + e);
       }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -19,7 +19,7 @@
 import * as extensionApi from '@podman-desktop/api';
 import type { Configuration, Preset } from './types';
 import { commander } from './daemon-commander';
-import { isEmpty, productName } from './util';
+import { getLoggerCallback, isEmpty, productName } from './util';
 import { crcStatus } from './crc-status';
 import { stopCrc } from './crc-stop';
 import { deleteCrc } from './crc-delete';
@@ -337,7 +337,7 @@ async function handleRecreate(
   } else if (result === 'Delete and Restart') {
     await stopCrc(telemetryLogger);
     await deleteCrc();
-    await startCrc(provider, defaultLogger, telemetryLogger);
+    await startCrc(provider, getLoggerCallback(undefined, defaultLogger), telemetryLogger);
     return true;
   } else if (result === 'Delete') {
     await deleteCrc();

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,6 +20,7 @@ import * as os from 'node:os';
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import type { Preset } from './types';
+import { LifecycleContext, Logger } from '@podman-desktop/api';
 
 export const productName = 'OpenShift Local';
 export const defaultPreset: Preset = 'openshift';
@@ -112,4 +113,13 @@ export function getPresetLabel(preset: Preset): string {
     default:
       return defaultPresetLabel;
   }
+}
+
+export function getLoggerCallback(context?: LifecycleContext, logger?: Logger): (data: string) => void {
+  return (data: string): void => {
+    if (data) {
+      context?.log?.log(data);
+      logger?.log(data);
+    }
+  };
 }


### PR DESCRIPTION
This PR refactors a bit the start action so that the error, if any, is propagated properly in the logger and caller.

Starting from the resources page
![start_error_1](https://github.com/user-attachments/assets/999067db-3747-4c9a-a1f2-3a4957f4c7a3)

Create and start the VM
![start_error_2](https://github.com/user-attachments/assets/85d73a9c-b6d9-4e68-a359-a50412afd774)
