### PR TITLE
fix: typescript typecheck error

### DIFF
--- a/src/crc-status.ts
+++ b/src/crc-status.ts
@@ -26,7 +26,7 @@ const setupStatus: Status = { CrcStatus: 'Need Setup', Preset: 'Unknown' };
 const errorStatus: Status = { CrcStatus: 'Error', Preset: 'Unknown' };
 
 export class CrcStatus {
-  private updateTimer: NodeJS.Timer;
+  private updateTimer: NodeJS.Timeout;
   private _status: Status;
   private isSetupGoing: boolean;
   private statusChangeEventEmitter = new extensionApi.EventEmitter<Status>();


### PR DESCRIPTION
```
$ npx tsc --noEmit
../crc-extension/src/crc-status.ts:65:21 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(intervalId: string | number | Timeout): void', gave the following error.
    Argument of type 'Timer' is not assignable to parameter of type 'string | number | Timeout'.
      Property '[Symbol.dispose]' is missing in type 'Timer' but required in type 'Timeout'.
  Overload 2 of 2, '(id: number): void', gave the following error.
    Argument of type 'Timer' is not assignable to parameter of type 'number'.

65       clearInterval(this.updateTimer);
                       ~~~~~~~~~~~~~~~~

  ../crc-extension/node_modules/@types/node/timers.d.ts:130:17
    130                 [Symbol.dispose](): void;
                        ~~~~~~~~~~~~~~~~
    '[Symbol.dispose]' is declared here.

Found 1 error in ../crc-extension/src/crc-status.ts:65
```