### PR TITLE
fix: run crc initialization after cleanup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -252,7 +252,7 @@ async function createCrcVm(
     return;
   }
 
-  if (!isNeedSetup()) {
+  if (isNeedSetup()) {
     const initResult = await initializeCrc(provider, extensionContext, telemetryLogger, logger);
     if (!initResult) {
       throw new Error(`${productName} not initialized.`);


### PR DESCRIPTION
This commit fixes condition for running initialization. It was  incorrectly changed when refactoring extension activation code.

Fix #252.