### PR TITLE
fix: remove step that creates PR to increment the version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,31 +75,6 @@ jobs:
           draft: true
           prerelease: true
 
-      - name: Create the PR to bump the version in the main branch (only if we're tagging from main branch)
-        if: ${{ github.event.inputs.branch == 'main' }}
-        run: |
-          git config --local user.name ${{ github.actor }}
-          CURRENT_VERSION=$(echo "${{ steps.TAG_UTIL.outputs.extVersion }}")
-          tmp=${CURRENT_VERSION%.*}
-          minor=${tmp#*.}
-          bumpedVersion=${CURRENT_VERSION%%.*}.$((minor + 1)).0
-          bumpedBranchName="bump-to-${bumpedVersion}"
-          git checkout -b "${bumpedBranchName}"
-          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${bumpedVersion}-next\",#g" package.json
-          git add package.json
-          git commit -s --amend -m "chore: bump version to ${bumpedVersion}"
-          git push origin "${bumpedBranchName}"
-          echo -e "📢 Bump version to ${bumpedVersion}\n\n${{ steps.TAG_UTIL.outputs.extVersion }} has been released.\n\n Time to switch to the new ${bumpedVersion} version 🥳" > /tmp/pr-title
-          pullRequestUrl=$(gh pr create --title "chore: 📢 Bump version to ${bumpedVersion}" --body-file /tmp/pr-title --head "${bumpedBranchName}" --base "main")
-          echo "📢 Pull request created: ${pullRequestUrl}"
-          echo "➡️ Flag the PR as being ready for review"
-          gh pr ready "${pullRequestUrl}"
-          echo "🔅 Mark the PR as being ok to be merged automatically"
-          gh pr merge "${pullRequestUrl}" --auto --rebase
-          git checkout ${{ steps.TAG_UTIL.outputs.githubTag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build:
     needs: [tag]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Task that creates PR cannot be used right now because of missing permissions for github actions. I'll send PR to increment version manually.