### PR TITLE
fix: update crc key name in pushImageToCrcCluster

### DIFF
--- a/src/image-handler.ts
+++ b/src/image-handler.ts
@@ -57,7 +57,7 @@ export async function pushImageToCrcCluster(image: ImageInfo): Promise<void> {
           getPodmanCli(),
           [
             '--url=ssh://core@127.0.0.1:2222/run/podman/podman.sock',
-            `--identity=${os.homedir()}/.crc/machines/crc/id_ecdsa`,
+            `--identity=${os.homedir()}/.crc/machines/crc/id_ed25519`,
             'load',
             '-i',
             filename,


### PR DESCRIPTION
### What does this PR do?
This PR updates the crc ssh key name to be able to push an image to crc cluster successfully.

### Screenshot / video of UI
![Screenshot from 2025-02-25 15-27-38](https://github.com/user-attachments/assets/05af2cb0-2c4b-4e3e-85e1-b2f4bdd98ee9)
![Screenshot from 2025-02-25 15-27-01](https://github.com/user-attachments/assets/ec3e60d5-4aea-406d-bdd0-e811369b5596)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/crc-org/crc-extension/issues/495

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature