### PR TITLE
chore: use newer ubuntu GH runner

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -88,7 +88,7 @@ jobs:
 
   lint-format-unit:
     name: linter, formatters and unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Upgraded GitHub Actions runner from ubuntu-20.04 to ubuntu-24.04