### PR TITLE
fix: use ubuntu 24.04 runner

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -88,7 +88,7 @@ jobs:
 
   lint-format-unit:
     name: linter, formatters and unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
 
   tag:
     name: Tagging
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
       extVersion: ${{ steps.TAG_UTIL.outputs.extVersion}}


### PR DESCRIPTION
Fixes #744

## Summary by Sourcery

Update GitHub Actions workflows to use the Ubuntu 24.04 runner.

CI:
- Switch pr-check job runner from ubuntu-20.04 to ubuntu-24.04
- Switch release tagging job runner from ubuntu-20.04 to ubuntu-24.04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow environments to use the latest Ubuntu version for automated checks and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->