### PR TITLE
fix: ensure setup state before creating a machine

### DIFF
--- a/src/preferences.spec.ts
+++ b/src/preferences.spec.ts
@@ -22,6 +22,7 @@ import * as daemon from './daemon-commander.js';
 import type { Configuration } from './types.js';
 import * as preferences from './preferences.js';
 import * as crcStatus from './crc-status.js';
+import { process } from '@podman-desktop/api';
 
 vi.mock('./crc-status', async () => {
   return {
@@ -37,6 +38,9 @@ vi.mock('@podman-desktop/api', async () => {
   return {
     configuration: {
       getConfiguration: vi.fn(),
+    },
+    process: {
+      exec: vi.fn(),
     },
     EventEmitter,
   };
@@ -76,7 +80,6 @@ test('should update configuration accordingly with params', async () => {
 });
 
 test('should update OpenShift Local preset based on form selection using connection audit', async () => {
-  const configSetMock = vi.spyOn(daemon.commander, 'configSet').mockResolvedValue(undefined);
   await preferences.connectionAuditor({ 'crc.factory.disksize': '20000000', 'crc.factory.preset': 'microshift' });
-  expect(configSetMock).toHaveBeenCalledWith({ preset: 'microshift' });
+  expect(process.exec).toHaveBeenCalledWith(expect.any(String), ['config', 'set', 'preset', 'microshift']);
 });

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -20,7 +20,8 @@ import * as extensionApi from '@podman-desktop/api';
 import type { Configuration, Preset } from './types.js';
 import { commander } from './daemon-commander.js';
 import { isEmpty, productName } from './util.js';
-import { getPreset } from './crc-cli.js';
+import { getCrcCli, getPreset } from './crc-cli.js';
+import { process } from '@podman-desktop/api';
 
 const presetChangedEventEmitter = new extensionApi.EventEmitter<Preset>();
 export const presetChangedEvent = presetChangedEventEmitter.event;
@@ -91,7 +92,7 @@ export async function connectionAuditor(items: extensionApi.AuditRequestItems): 
     preset !== items['crc.factory.preset']
   ) {
     try {
-      await commander.configSet({ preset: items['crc.factory.preset'] });
+      await process.exec(getCrcCli(), ['config', 'set', 'preset', items['crc.factory.preset']]);
       presetChangedEventEmitter.fire(items['crc.factory.preset']);
     } catch (e) {
       console.error('Unable to update preset', e);


### PR DESCRIPTION
Fixes #206

To test:

- run `crc cleanup` and `rm -rf $HOME/.crc`
- create an OpenShift Local resource (don't follow onboarding or dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic setup now triggers the required CLI-based preset application early during connection initialization to ensure correct configuration before saving or starting components.

* **Refactor**
  * Reworked preset configuration flow to use the external CLI execution path for more reliable and consistent handling.

* **Tests**
  * Updated tests to assert the external CLI invocation behavior that applies the preset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->