### PR TITLE
chore: update preset on activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,8 +20,8 @@ import * as extensionApi from '@podman-desktop/api';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
-import { commander, isDaemonRunning } from './daemon-commander.js';
-import { defaultPreset, getPresetLabel, isWindows, productName, providerId } from './util.js';
+import { isDaemonRunning } from './daemon-commander.js';
+import { getPresetLabel, isWindows, productName, providerId } from './util.js';
 import type { CrcVersion } from './crc-cli.js';
 import { getPreset } from './crc-cli.js';
 import { getCrcVersion } from './crc-cli.js';
@@ -355,17 +355,6 @@ async function handleDelete(
   }
 }
 
-async function readPreset(): Promise<Preset> {
-  try {
-    const config = await commander.configGet();
-    return config.preset;
-  } catch (err) {
-    console.log('error while getting preset', err);
-    // return default one
-    return defaultPreset;
-  }
-}
-
 async function connectToCrc(): Promise<void> {
   await crcStatus.initialize();
   crcStatus.startStatusUpdate();
@@ -381,7 +370,7 @@ async function presetChanged(
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {
   // detect preset of CRC
-  const preset = await getPreset() ?? 'openshift';
+  const preset = (await getPreset()) ?? 'openshift';
   extensionApi.context.setValue(CRC_PRESET_KEY, preset);
   updateProviderVersionWithPreset(provider, preset);
 


### PR DESCRIPTION
Upon checking https://github.com/crc-org/crc-extension/pull/932, I found out that any preset loading from the config before CRC is setup will lead to error (only in `console.log` with https://github.com/crc-org/crc-extension/pull/932), and it will always use the default preset even when the config has a the microshift preset since the preset check uses the socket instead of the CLI.
This PR updated the activation to use the CLI preset check instead of the socket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preset synchronization now always runs during extension activation, ensuring settings are up-to-date.
  * Preset detection reliably uses CLI-provided configuration with a default fallback and ensures the provider version reflects the current preset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->