### PR TITLE
fix: update release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,11 @@
 
 name: release
 
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Updates the release workflow's permissions to be able to create PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions for improved security configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->