### PR TITLE
fix: fixed ghost resource

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -403,6 +403,10 @@ async function presetChanged(
     // podman connection
     registerPodmanConnection(provider, extensionContext);
   } else if (preset === 'openshift' || preset === 'microshift') {
-    registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
+    // Only register connection if a cluster actually exists (not 'No Cluster', 'Unknown', or 'Need Setup')
+    const currentStatus = crcStatus.status.CrcStatus;
+    if (currentStatus !== 'No Cluster' && currentStatus !== 'Unknown' && currentStatus !== 'Need Setup') {
+      registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
+    }
   }
 }


### PR DESCRIPTION
Fixes creation of ghost resource 

Closes #947 

Testing: 

Go to resources -> create new -> try to switch preset.
Dont create new but cancel and go back, there should be no "Ghost" anymore 

You can also try this from main 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where OpenShift local cluster registration was incorrectly occurring regardless of actual cluster status. The system now validates cluster state before attempting registration, preventing improper initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->