### PR TITLE
chore(test): ensure hasha is a real folder not a symlink

### DIFF
--- a/.extfiles
+++ b/.extfiles
@@ -4,3 +4,4 @@ icon.png
 README.md
 dist/**
 !dist/pnpm-lock.yaml
+!dist/.npmrc

--- a/.extfiles
+++ b/.extfiles
@@ -5,3 +5,4 @@ README.md
 dist/**
 !dist/pnpm-lock.yaml
 !dist/.npmrc
+!dist/package.json

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -50,9 +50,13 @@ if (fs.existsSync(builtinDirectory)) {
 const distDirectory = path.resolve(__dirname, '../dist');
 mkdirp.sync(distDirectory);
 fs.writeFileSync(path.join(distDirectory, '.npmrc'), 'node-linker=hoisted\n');
+fs.writeFileSync(path.join(distDirectory, 'package.json'), '{}');
 
-// install external modules into dist folder
-cproc.exec('pnpm add hasha@^7.0.0', { cwd: distDirectory }, (error, stdout, stderr) => {
+// Install external modules into dist folder.
+// --store-dir reuses the root project's store so pnpm doesn't fail with
+// ERR_PNPM_UNEXPECTED_STORE when running inside a subdirectory.
+const storeDir = cproc.execSync('pnpm store path', { encoding: 'utf8' }).trim();
+cproc.exec(`pnpm add hasha@^7.0.0 --store-dir="${storeDir}"`, { cwd: distDirectory }, (error, stdout, stderr) => {
   if (error) {
     console.log(stdout);
     console.log(stderr);

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -47,10 +47,12 @@ if (fs.existsSync(builtinDirectory)) {
 // pnpm uses symlinks in node_modules by default, which break when the dist
 // folder is packaged into a .cdix zip or OCI image (especially on Windows).
 // Force a flat, hoisted layout so the hasha package is a real directory.
-fs.writeFileSync('./dist/.npmrc', 'node-linker=hoisted\n');
+const distDirectory = path.resolve(__dirname, '../dist');
+mkdirp.sync(distDirectory);
+fs.writeFileSync(path.join(distDirectory, '.npmrc'), 'node-linker=hoisted\n');
 
 // install external modules into dist folder
-cproc.exec('pnpm add hasha@^7.0.0', { cwd: './dist' }, (error, stdout, stderr) => {
+cproc.exec('pnpm add hasha@^7.0.0', { cwd: distDirectory }, (error, stdout, stderr) => {
   if (error) {
     console.log(stdout);
     console.log(stderr);

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -44,6 +44,11 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
+// pnpm uses symlinks in node_modules by default, which break when the dist
+// folder is packaged into a .cdix zip or OCI image (especially on Windows).
+// Force a flat, hoisted layout so the hasha package is a real directory.
+fs.writeFileSync('./dist/.npmrc', 'node-linker=hoisted\n');
+
 // install external modules into dist folder
 cproc.exec('pnpm add hasha@^7.0.0', { cwd: './dist' }, (error, stdout, stderr) => {
   if (error) {


### PR DESCRIPTION
Signed-off-by: Vladimir Lazar <vlazar@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/packaging configuration to use a hoisted node linker strategy for distribution builds to control dependency layout.
  * Adjusted distribution file exclusion rules to preserve specific package metadata files while keeping other distribution contents unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->