### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "publisher": "redhat",
   "name": "openshift-local",
+  "repository": "https://github.com/crc-org/crc-extension",
+  "homepage": "https://github.com/crc-org/crc-extension#readme",
   "displayName": "Red Hat OpenShift Local",
   "description": "Integration for Red Hat OpenShift Local clusters",
   "version": "2.4.0-next",


### PR DESCRIPTION
### What does this PR do?

Add missing `repository` and `homepage` fields in the extension `package.json`.

### Screenshot / video of UI

N/A (metadata-only change)

### What issues does this PR fix or reference?

Closes #1102

### How to test this PR?

1. Open `package.json`.
2. Verify both `repository` and `homepage` are present and point to this GitHub repository.
3. Confirm no other files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with repository and homepage information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crc-org/crc-extension/pull/1111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->