### PR TITLE
chore: make command registration error non-blocking for other commands

### DIFF
--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -85,3 +85,23 @@ test('commands are reregistered on crc status change to not running excluding CR
 
   expect(extensionApi.commands.registerCommand).toHaveBeenCalledTimes(5);
 });
+
+test('If a command registration throws an error, it does not block the registration of other commands', () => {
+  let statusChangeEvent: (e: Status) => unknown;
+  vi.mocked(crcStatus.onStatusChange).mockImplementation(fn => {
+    statusChangeEvent = fn;
+    return Disposable.from();
+  });
+
+  vi.mocked(extensionApi.commands.registerCommand).mockImplementationOnce(() => {
+    throw new Error('error registering command');
+  });
+
+  const commandManager = new CommandManager();
+  commandManager.setTelemetryLogger(telemetryLoggerMock);
+  expect(statusChangeEvent).toBeDefined();
+
+  statusChangeEvent({ CrcStatus: 'Running' });
+
+  expect(extensionApi.commands.registerCommand).toHaveBeenCalledTimes(6);
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -108,19 +108,19 @@ export class CommandManager {
 export const commandManager = new CommandManager();
 
 export function addCommands(telemetryLogger: extensionApi.TelemetryLogger, status?: Status): void {
-  try {
-    registerOpenTerminalCommand();
-    registerOpenConsoleCommand();
-    registerLogInCommands();
-    registerDeleteCommand();
+  registerOpenTerminalCommand();
+  registerOpenConsoleCommand();
+  registerLogInCommands();
+  registerDeleteCommand();
 
-    if (status && status.CrcStatus === 'Running') {
+  if (status && status.CrcStatus === 'Running') {
+    try {
       commandManager.addCommand(CRC_PUSH_IMAGE_TO_CLUSTER, image => {
         telemetryLogger.logUsage('pushImage');
         return pushImageToCrcCluster(image);
       });
+    } catch {
+      // ignore
     }
-  } catch (err: unknown) {
-    console.log('Commands already added');
   }
 }

--- a/src/crc-console.ts
+++ b/src/crc-console.ts
@@ -21,13 +21,17 @@ import { commandManager } from './command.js';
 import { commander } from './daemon-commander.js';
 
 export function registerOpenConsoleCommand(): void {
-  commandManager.addTrayCommand({
-    id: 'crc.open.console',
-    label: 'Open Console',
-    isEnabled: status => status.CrcStatus === 'Running' && status.Preset === 'openshift',
-    isVisible: status => status.Preset === 'openshift',
-    callback: openConsole,
-  });
+  try {
+    commandManager.addTrayCommand({
+      id: 'crc.open.console',
+      label: 'Open Console',
+      isEnabled: status => status.CrcStatus === 'Running' && status.Preset === 'openshift',
+      isVisible: status => status.Preset === 'openshift',
+      callback: openConsole,
+    });
+  } catch {
+    // ignore
+  }
 }
 
 async function openConsole(): Promise<void> {

--- a/src/crc-delete.ts
+++ b/src/crc-delete.ts
@@ -23,13 +23,17 @@ import { productName } from './util.js';
 import { commandManager } from './command.js';
 
 export function registerDeleteCommand(): void {
-  commandManager.addTrayCommand({
-    id: 'crc.delete',
-    label: 'Delete',
-    visible: true,
-    callback: deleteCrc,
-    isEnabled: status => status.CrcStatus === 'Running' || status.CrcStatus === 'Stopped',
-  });
+  try {
+    commandManager.addTrayCommand({
+      id: 'crc.delete',
+      label: 'Delete',
+      visible: true,
+      callback: deleteCrc,
+      isEnabled: status => status.CrcStatus === 'Running' || status.CrcStatus === 'Stopped',
+    });
+  } catch {
+    // ignore
+  }
 }
 
 export async function deleteCrc(suppressNotification = false): Promise<boolean> {

--- a/src/crc-status.ts
+++ b/src/crc-status.ts
@@ -83,7 +83,12 @@ export class CrcStatus {
 
     try {
       // initial status
+      const oldStatus = this._status;
       this._status = await commander.status();
+      // notify listeners when status changed
+      if (oldStatus.CrcStatus !== this._status.CrcStatus) {
+        this.statusChangeEventEmitter.fire(this._status);
+      }
     } catch (err) {
       console.error('error in CRC extension', err);
       this._status = defaultStatus;

--- a/src/dev-terminal.ts
+++ b/src/dev-terminal.ts
@@ -30,13 +30,17 @@ import which from 'which';
 import { commandManager } from './command.js';
 
 export function registerOpenTerminalCommand(): void {
-  commandManager.addTrayCommand({
-    id: 'crc.dev.terminal',
-    label: 'Open developer terminal',
-    callback: openTerminalWithOC,
-    visible: true,
-    isEnabled: status => status.CrcStatus === 'Running',
-  });
+  try {
+    commandManager.addTrayCommand({
+      id: 'crc.dev.terminal',
+      label: 'Open developer terminal',
+      callback: openTerminalWithOC,
+      visible: true,
+      isEnabled: status => status.CrcStatus === 'Running',
+    });
+  } catch {
+    // ignore
+  }
 }
 
 async function openTerminalWithOC(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
 
   crcVersion = await getCrcVersion();
   const telemetryLogger = extensionApi.env.createTelemetryLogger();
+  commandManager.setTelemetryLogger(telemetryLogger);
 
   const detectionChecks: extensionApi.ProviderDetectionCheck[] = [];
   let hasDaemonRunning = false;
@@ -74,7 +75,6 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
   detectionChecks.push(...getCrcDetectionChecks(crcVersion));
 
   commandManager.setExtContext(extensionContext);
-  commandManager.setTelemetryLogger(telemetryLogger);
 
   const links: extensionApi.Link[] = [
     {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
     await crcStatus.initialize();
 
     if (!isNeedSetup()) {
-      await connectToCrc();
+      crcStatus.startStatusUpdate();
     }
 
     hasDaemonRunning = await isDaemonRunning();

--- a/src/login-commands.ts
+++ b/src/login-commands.ts
@@ -28,21 +28,29 @@ if (isWindows()) {
 }
 
 export function registerLogInCommands(): void {
-  commandManager.addTrayCommand({
-    id: 'crc.copy.login.admin',
-    label: 'Copy OC login command (admin)',
-    isEnabled: status => status.CrcStatus === 'Running',
-    isVisible: status => status.Preset === 'openshift',
-    callback: copyAdmin,
-  });
+  try {
+    commandManager.addTrayCommand({
+      id: 'crc.copy.login.admin',
+      label: 'Copy OC login command (admin)',
+      isEnabled: status => status.CrcStatus === 'Running',
+      isVisible: status => status.Preset === 'openshift',
+      callback: copyAdmin,
+    });
+  } catch {
+    // ignore
+  }
 
-  commandManager.addTrayCommand({
-    id: 'crc.copy.login.developer',
-    label: 'Copy OC login command (developer)',
-    isEnabled: status => status.CrcStatus === 'Running',
-    isVisible: status => status.Preset === 'openshift',
-    callback: copyDeveloper,
-  });
+  try {
+    commandManager.addTrayCommand({
+      id: 'crc.copy.login.developer',
+      label: 'Copy OC login command (developer)',
+      isEnabled: status => status.CrcStatus === 'Running',
+      isVisible: status => status.Preset === 'openshift',
+      callback: copyDeveloper,
+    });
+  } catch {
+    // ignore
+  }
 }
 
 async function copyAdmin(): Promise<void> {


### PR DESCRIPTION
If a command registration throws an error for some reason (command already registered or no provider matching provider id), it won't block the registration of other commands. In addition, when initalizing the crcStatus, it also check for old status and fires statusChangeEvent if the status changed.

Closes https://github.com/crc-org/crc-extension/issues/972

To reproduce this bug, you should have an OpenShift Local cluster running before the CRC extension starts:

- Start the cluster outside Podman Desktop, and then open it while the cluster is still running

or
- Start the cluster from anywhere, and then stop and start the CRC extension from within Podman Desktop

In both of this cases, the push image to cluster option won't shows up even when the cluster is running.
With this fix, you should be able to see the push image to cluster option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Status change notifications now properly fire during initialization.
  * Improved error handling for command registration to enhance stability.

* **Changes**
  * Adjusted initialization flow for better startup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->