### PR TITLE
feat: propagate lifecycle errors via connection error property

### DIFF
--- a/src/crc-start.spec.ts
+++ b/src/crc-start.spec.ts
@@ -17,18 +17,26 @@
  ***********************************************************************/
 
 import type * as extensionApi from '@podman-desktop/api';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import * as crcCli from './crc-cli.js';
 import * as crcSetup from './crc-setup.js';
 import { startCrc } from './crc-start.js';
 import * as logProvider from './log-provider.js';
 import * as daemon from './daemon-commander.js';
 import type { StartInfo } from './types.js';
+import { crcStatus } from './crc-status.js';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
     EventEmitter: vi.fn(),
+    window: {
+      showErrorMessage: vi.fn(),
+    },
   };
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
 });
 
 test('setUpCRC is skipped if already setup, it just perform the daemon start command', async () => {
@@ -70,4 +78,58 @@ test('set up CRC and then start the daemon', async () => {
   );
   expect(setUpMock).toBeCalled();
   expect(startDaemon).toBeCalled();
+});
+
+test('startCrc throws when start result is not Running', async () => {
+  vi.spyOn(crcCli, 'execPromise').mockResolvedValue('');
+  vi.spyOn(logProvider.crcLogProvider, 'startSendingLogs').mockResolvedValue();
+  vi.spyOn(daemon.commander, 'start').mockResolvedValue({
+    Status: 'Stopped',
+  } as unknown as StartInfo);
+  const updateStatus = vi.fn();
+
+  await expect(
+    startCrc(
+      { updateStatus } as unknown as extensionApi.Provider,
+      {} as extensionApi.Logger,
+      { logUsage: vi.fn() } as unknown as extensionApi.TelemetryLogger,
+    ),
+  ).rejects.toThrow('Error during starting');
+
+  expect(updateStatus).toHaveBeenCalledWith('error');
+});
+
+test('startCrc throws when setup fails', async () => {
+  vi.spyOn(crcCli, 'execPromise').mockRejectedValue('daemon not running');
+  vi.spyOn(crcSetup, 'needSetup').mockResolvedValue(true);
+  vi.spyOn(crcSetup, 'setUpCrc').mockRejectedValue(new Error('setup failed'));
+  vi.spyOn(crcStatus, 'setSetupRunning').mockReturnValue();
+  const updateStatus = vi.fn();
+
+  await expect(
+    startCrc(
+      { updateStatus } as unknown as extensionApi.Provider,
+      { error: vi.fn() } as unknown as extensionApi.Logger,
+      { logUsage: vi.fn() } as unknown as extensionApi.TelemetryLogger,
+    ),
+  ).rejects.toThrow('setup failed');
+
+  expect(updateStatus).toHaveBeenCalledWith('stopped');
+});
+
+test('startCrc throws on general error', async () => {
+  vi.spyOn(crcCli, 'execPromise').mockResolvedValue('');
+  vi.spyOn(logProvider.crcLogProvider, 'startSendingLogs').mockResolvedValue();
+  vi.spyOn(daemon.commander, 'start').mockRejectedValue(new Error('connection timeout'));
+  const updateStatus = vi.fn();
+
+  await expect(
+    startCrc(
+      { updateStatus } as unknown as extensionApi.Provider,
+      {} as extensionApi.Logger,
+      { logUsage: vi.fn() } as unknown as extensionApi.TelemetryLogger,
+    ),
+  ).rejects.toThrow('connection timeout');
+
+  expect(updateStatus).toHaveBeenCalledWith('stopped');
 });

--- a/src/crc-start.ts
+++ b/src/crc-start.ts
@@ -39,7 +39,7 @@ export async function startCrc(
   provider: extensionApi.Provider,
   logger: extensionApi.Logger,
   telemetryLogger: extensionApi.TelemetryLogger,
-): Promise<boolean> {
+): Promise<void> {
   telemetryLogger.logUsage('crc.start', {
     preset: crcStatus.status.Preset,
   });
@@ -53,7 +53,7 @@ export async function startCrc(
       } catch (error) {
         logger.error(error);
         provider.updateStatus('stopped');
-        return;
+        throw error instanceof Error ? error : new Error(String(error));
       } finally {
         crcStatus.setSetupRunning(false);
       }
@@ -62,10 +62,12 @@ export async function startCrc(
     const result = await commander.start();
     if (result.Status === 'Running') {
       provider.updateStatus('started');
-      return true;
+      return;
     } else {
       provider.updateStatus('error');
-      await extensionApi.window.showErrorMessage(`Error during starting ${productName}: ${result.Status}`);
+      const errorMsg = `Error during starting ${productName}: ${result.Status}`;
+      await extensionApi.window.showErrorMessage(errorMsg);
+      throw new Error(errorMsg);
     }
   } catch (err) {
     if (typeof err.message === 'string') {
@@ -81,14 +83,14 @@ export async function startCrc(
       } else if (err.name === 'RequestError' && err.code === 'ECONNRESET') {
         // look like crc start normally, but we receive empty response from socket, so 'got' generate an error
         provider.updateStatus('started');
-        return true;
+        return;
       }
     }
     await extensionApi.window.showErrorMessage(`${productName} start error: ${err}`);
     console.error(err);
     provider.updateStatus('stopped');
+    throw err instanceof Error ? err : new Error(String(err));
   }
-  return false;
 }
 
 async function askAndStorePullSecret(logger: extensionApi.Logger): Promise<boolean> {

--- a/src/crc-stop.ts
+++ b/src/crc-stop.ts
@@ -28,5 +28,6 @@ export async function stopCrc(telemetryLogger: extensionApi.TelemetryLogger): Pr
     crcLogProvider.stopSendingLogs();
   } catch (err) {
     console.error(err);
+    throw err instanceof Error ? err : new Error(String(err));
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,8 +256,12 @@ async function createCrcVm(
     }
   }
 
-  const hasStarted = await startCrc(provider, logger, telemetryLogger);
-  if (!connectionDisposable && hasStarted) {
+  try {
+    await startCrc(provider, logger, telemetryLogger);
+  } catch {
+    return;
+  }
+  if (!connectionDisposable) {
     addCommands(telemetryLogger);
     await presetChanged(provider, extensionContext, telemetryLogger);
   }
@@ -340,11 +344,23 @@ function registerOpenShiftLocalCluster(
     },
     start: async ctx => {
       provider.updateStatus('starting');
-      await startCrc(provider, ctx.log, telemetryLogger);
+      try {
+        await startCrc(provider, ctx.log, telemetryLogger);
+        kubernetesProviderConnection.error = undefined;
+      } catch (err) {
+        kubernetesProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
-    stop: () => {
+    stop: async () => {
       provider.updateStatus('stopping');
-      return stopCrc(telemetryLogger);
+      try {
+        await stopCrc(telemetryLogger);
+        kubernetesProviderConnection.error = undefined;
+      } catch (err) {
+        kubernetesProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
   };
   extensionContext.subscriptions.push(connectionDisposable);


### PR DESCRIPTION
Propagate lifecycle errors to the Podman Desktop UI by setting the
`error` property on provider connections.

startCrc and stopCrc now throw on failure so the provider registry
can capture errors automatically. The Kubernetes connection lifecycle
handlers set connection.error on failure and clear it on success.

Closes #1095
Part of https://github.com/podman-desktop/podman-desktop/issues/17222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting throughout CRC start/stop operations
  * Error messages now properly displayed to users on connection failures
  * Enhanced error normalization and lifecycle management during CRC initialization

* **Tests**
  * Added comprehensive test coverage for CRC startup failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->