### PR TITLE
chore: periodically check config preset and use separate instance preset

### DIFF
--- a/src/crc-status.ts
+++ b/src/crc-status.ts
@@ -17,9 +17,10 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import type { Status, CrcStatus as CrcStatusApi } from './types.js';
+import type { Status, CrcStatus as CrcStatusApi, Preset } from './types.js';
 import { commander } from './daemon-commander.js';
 import { needSetup } from './crc-setup.js';
+import { isPreset, presetChanged } from './preferences.js';
 
 const defaultStatus: Status = { CrcStatus: 'Unknown', Preset: 'openshift' };
 const setupStatus: Status = { CrcStatus: 'Need Setup', Preset: 'Unknown' };
@@ -28,12 +29,14 @@ const errorStatus: Status = { CrcStatus: 'Error', Preset: 'Unknown' };
 export class CrcStatus {
   private updateTimer: NodeJS.Timeout;
   private _status: Status;
+  private _preset: Preset;
   private isSetupGoing: boolean;
   private statusChangeEventEmitter = new extensionApi.EventEmitter<Status>();
   public readonly onStatusChange = this.statusChangeEventEmitter.event;
 
   constructor() {
     this._status = defaultStatus;
+    this._preset = 'openshift';
   }
 
   startStatusUpdate(): void {
@@ -52,6 +55,13 @@ export class CrcStatus {
         // notify listeners when status changed
         if (oldStatus.CrcStatus !== this._status.CrcStatus) {
           this.statusChangeEventEmitter.fire(this._status);
+        }
+
+        const oldPreset = this._preset;
+        this._preset = (await commander.configGet()).preset;
+
+        if (oldPreset != this._preset) {
+          presetChanged(this._preset);
         }
       } catch (e) {
         console.error('CRC Status tick: ' + e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import { crcStatus } from './crc-status.js';
 import { startCrc } from './crc-start.js';
 import { needSetup, setUpCrc } from './crc-setup.js';
 import { deleteCrc } from './crc-delete.js';
-import { connectionAuditor, presetChangedEvent, saveConfig, syncProxy } from './preferences.js';
+import { connectionAuditor, isPreset, presetChangedEvent, saveConfig, syncProxy } from './preferences.js';
 import { stopCrc } from './crc-stop.js';
 import { addCommands, commandManager } from './command.js';
 import { defaultLogger } from './logger.js';
@@ -118,6 +118,10 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
 
   if (crcStatus.getProviderStatus() === 'installed' || crcStatus.status.CrcStatus === 'No Cluster') {
     registerProviderConnectionFactory(provider, extensionContext, telemetryLogger);
+  }
+
+  if (crcStatus.status.CrcStatus === 'Running' || crcStatus.status.CrcStatus === 'Stopped' || crcStatus.status.CrcStatus === 'Starting' || crcStatus.status.CrcStatus === 'Stopping' && !connectionDisposable) {
+    registerOpenShiftLocalCluster(isPreset(crcStatus.status.Preset) ? getPresetLabel(crcStatus.status.Preset) : crcStatus.status.Preset, provider, extensionContext, telemetryLogger)
   }
 
   //if crc installed
@@ -257,6 +261,8 @@ async function createCrcVm(
   }
 
   try {
+    const preset = (await getPreset()) ?? 'openshift';
+    registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
     await startCrc(provider, logger, telemetryLogger);
   } catch {
     return;
@@ -402,12 +408,8 @@ async function presetChanged(
   updateProviderVersionWithPreset(provider, preset);
 
   const extConfig = extensionApi.configuration.getConfiguration();
+  console.log('changed preset to:' + preset);
   await extConfig.update('crc.factory.preset', preset);
-
-  if (connectionDisposable) {
-    connectionDisposable.dispose();
-    connectionDisposable = undefined;
-  }
 
   if (preset === 'podman') {
     // do nothing
@@ -418,11 +420,5 @@ async function presetChanged(
 
     // podman connection
     registerPodmanConnection(provider, extensionContext);
-  } else if (preset === 'openshift' || preset === 'microshift') {
-    // Only register connection if a cluster actually exists (not 'No Cluster', 'Unknown', or 'Need Setup')
-    const currentStatus = crcStatus.status.CrcStatus;
-    if (currentStatus !== 'No Cluster' && currentStatus !== 'Unknown' && currentStatus !== 'Need Setup') {
-      registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
-    }
   }
 }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -74,7 +74,7 @@ async function handleProxyChange(proxy?: extensionApi.ProxySettings): Promise<vo
   }
 }
 
-function isPreset(data: string): data is Preset {
+export function isPreset(data: string | undefined): data is Preset {
   if (data === 'microshift' || data === 'openshift' || data === 'podman') {
     return true;
   } else {
@@ -126,4 +126,8 @@ export async function saveConfig(params: {
   }
 
   await commander.configSet(configuration);
+}
+
+export function presetChanged(preset: Preset): void{
+  presetChangedEventEmitter.fire(preset);
 }


### PR DESCRIPTION
During the status check, it now also check for the config preset in case was changed outside of PD, and updates the preset label (near the version) accordingly.
In addition, it also uses the (separate) preset of the current instance taken from the CrcStatus to make sure that it is not changed when the config preset in updated