### PR TITLE
chore: update crc socket path for non-Windows OSs

### DIFF
--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -20,12 +20,20 @@ import type { Response } from 'got';
 import got from 'got';
 import { isWindows } from './util.js';
 import type { ConfigKeys, Configuration, StartInfo, Status } from './types.js';
+import { getCrcVersion } from './crc-cli.js';
+import { compare } from 'compare-versions';
 
 export class DaemonCommander {
   private apiPath: string;
 
-  constructor() {
-    this.apiPath = `http://unix:${process.env.HOME}/.crc/sockets/crc-http.sock:/api`;
+  constructor(crcVersion: string) {
+    let crcSocketDir;
+    if (compare(crcVersion, '2.62.0', '>=')) {
+      crcSocketDir = '.crc/sockets';
+    } else {
+      crcSocketDir = '.crc';
+    }
+    this.apiPath = `http://unix:${process.env.HOME}/${crcSocketDir}/crc-http.sock:/api`;
 
     if (isWindows()) {
       this.apiPath = 'http://unix://?/pipe/crc-http:/api';
@@ -158,7 +166,8 @@ export class DaemonCommander {
   }
 }
 
-export const commander = new DaemonCommander();
+const version = await getCrcVersion()
+export const commander = new DaemonCommander(version?.version);
 
 export async function isPullSecretMissing(): Promise<boolean> {
   let result = true;

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -26,18 +26,19 @@ import { compare } from 'compare-versions';
 export class DaemonCommander {
   private apiPath: string;
 
-  constructor(crcVersion: string) {
-    let crcSocketDir;
-    if (compare(crcVersion, '2.62.0', '>=')) {
-      crcSocketDir = '.crc/sockets';
-    } else {
-      crcSocketDir = '.crc';
-    }
-    this.apiPath = `http://unix:${process.env.HOME}/${crcSocketDir}/crc-http.sock:/api`;
+  constructor() {
+    
+    this.apiPath = `http://unix:${process.env.HOME}/.crc/sockets/crc-http.sock:/api`;
 
     if (isWindows()) {
       this.apiPath = 'http://unix://?/pipe/crc-http:/api';
     }
+  }
+
+  checkSocketPath(crcVersion: string): void {
+    if (compare(crcVersion, '2.62.0', '<')) {
+      this.apiPath = `http://unix:${process.env.HOME}/.crc/crc-http.sock:/api`;
+    } 
   }
 
   async status(): Promise<Status> {
@@ -166,8 +167,7 @@ export class DaemonCommander {
   }
 }
 
-const version = await getCrcVersion()
-export const commander = new DaemonCommander(version?.version);
+export const commander = new DaemonCommander();
 
 export async function isPullSecretMissing(): Promise<boolean> {
   let result = true;

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -25,7 +25,7 @@ export class DaemonCommander {
   private apiPath: string;
 
   constructor() {
-    this.apiPath = `http://unix:${process.env.HOME}/.crc/crc-http.sock:/api`;
+    this.apiPath = `http://unix:${process.env.HOME}/.crc/sockets/crc-http.sock:/api`;
 
     if (isWindows()) {
       this.apiPath = 'http://unix://?/pipe/crc-http:/api';

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -24,6 +24,7 @@ import { compare } from 'compare-versions';
 
 export class DaemonCommander {
   private apiPath: string;
+  private crcVersion: string | undefined;
 
   constructor() {
     this.apiPath = `http://unix:${process.env.HOME}/.crc/sockets/crc-http.sock:/api`;
@@ -34,9 +35,16 @@ export class DaemonCommander {
   }
 
   setVersion(crcVersion: string): void {
-    if (!isWindows() && compare(crcVersion, '2.62.0', '<')) {
-      this.apiPath = `http://unix:${process.env.HOME}/.crc/crc-http.sock:/api`;
+    if (isWindows()) {
+      return;
     }
+    if (compare(crcVersion, '2.62.0', '<')) {
+      this.apiPath = `http://unix:${process.env.HOME}/.crc/crc-http.sock:/api`;
+    } else if (this.crcVersion && compare(this.crcVersion, '2.62.0', '<') && compare(crcVersion, '2.62.0', '>=')) {
+      // updating from older crc version less than 2.62.0 to 2.62.0 or later should also update socket path
+      this.apiPath = `http://unix:${process.env.HOME}/.crc/sockets/crc-http.sock:/api`;
+    }
+    this.crcVersion = crcVersion;
   }
 
   async status(): Promise<Status> {

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -20,14 +20,12 @@ import type { Response } from 'got';
 import got from 'got';
 import { isWindows } from './util.js';
 import type { ConfigKeys, Configuration, StartInfo, Status } from './types.js';
-import { getCrcVersion } from './crc-cli.js';
 import { compare } from 'compare-versions';
 
 export class DaemonCommander {
   private apiPath: string;
 
   constructor() {
-    
     this.apiPath = `http://unix:${process.env.HOME}/.crc/sockets/crc-http.sock:/api`;
 
     if (isWindows()) {
@@ -38,7 +36,7 @@ export class DaemonCommander {
   checkSocketPath(crcVersion: string): void {
     if (compare(crcVersion, '2.62.0', '<')) {
       this.apiPath = `http://unix:${process.env.HOME}/.crc/crc-http.sock:/api`;
-    } 
+    }
   }
 
   async status(): Promise<Status> {

--- a/src/daemon-commander.ts
+++ b/src/daemon-commander.ts
@@ -33,8 +33,8 @@ export class DaemonCommander {
     }
   }
 
-  checkSocketPath(crcVersion: string): void {
-    if (compare(crcVersion, '2.62.0', '<')) {
+  setVersion(crcVersion: string): void {
+    if (!isWindows() && compare(crcVersion, '2.62.0', '<')) {
       this.apiPath = `http://unix:${process.env.HOME}/.crc/crc-http.sock:/api`;
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,8 +63,8 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
   let hasDaemonRunning = false;
 
   if (crcVersion) {
+    commander.setVersion(crcVersion.version);
     await crcStatus.initialize();
-    commander.checkSocketPath(crcVersion.version);
 
     if (!isNeedSetup()) {
       crcStatus.startStatusUpdate();
@@ -146,6 +146,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
         return crcInstaller.doInstallCrc(provider, logger, async (setupResult: boolean, newVersion: CrcVersion) => {
           provider.updateStatus('installed');
           if (newVersion) {
+            commander.setVersion(newVersion.version);
             crcVersion = newVersion;
           }
           if (!setupResult) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import * as extensionApi from '@podman-desktop/api';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
-import { isDaemonRunning } from './daemon-commander.js';
+import { isDaemonRunning, commander } from './daemon-commander.js';
 import { getPresetLabel, isWindows, productName, providerId } from './util.js';
 import type { CrcVersion } from './crc-cli.js';
 import { getCrcCli } from './crc-cli.js';
@@ -64,6 +64,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
 
   if (crcVersion) {
     await crcStatus.initialize();
+    commander.checkSocketPath(crcVersion.version);
 
     if (!isNeedSetup()) {
       crcStatus.startStatusUpdate();


### PR DESCRIPTION
This PR updates the crc socket path to the new one, with backwards compatibility based on version

Fixes https://github.com/crc-org/crc-extension/issues/1157

Should be tested with CRC 2.62.0 and older version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across CRC versions by automatically selecting the correct HTTP socket path.
  * Ensures older CRC installs use the legacy socket when the configured version is below 2.62.0, and switches back to the newer socket on upgrades to 2.62.0+.
* **New Features**
  * Applies the configured CRC version context during extension activation and immediately after CRC installation completes, so the extension targets the correct API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->