### PR TITLE
chore: update commander crc version on update

### DIFF
--- a/src/install/crc-install.ts
+++ b/src/install/crc-install.ts
@@ -185,11 +185,11 @@ export class CrcInstall {
       telemetry.logUsage('crc.update.start', { version: newVersion });
       await this.getInstaller().update(updateInfo.newVersion, logger);
       const crcVersion = await getCrcVersion();
+      provider.updateDetectionChecks(getCrcDetectionChecks(crcVersion));
       if (crcVersion) {
+        provider.updateVersion(crcVersion.version);
         commander.setVersion(crcVersion.version);
       }
-      provider.updateDetectionChecks(getCrcDetectionChecks(crcVersion));
-      provider.updateVersion(crcVersion.version);
       this.crcCliInfo.ignoreVersionUpdate = undefined;
     } else if (answer === 'Ignore') {
       telemetry.logUsage('crc.update.ignored', { version: newVersion });

--- a/src/install/crc-install.ts
+++ b/src/install/crc-install.ts
@@ -34,6 +34,7 @@ import type { CrcReleaseInfo, CrcUpdateInfo } from '../types.js';
 
 import { compare } from 'compare-versions';
 import { isFileExists, productName } from '../util.js';
+import { commander } from '../daemon-commander.js';
 
 const crcLatestReleaseUrl =
   'https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json';
@@ -184,6 +185,9 @@ export class CrcInstall {
       telemetry.logUsage('crc.update.start', { version: newVersion });
       await this.getInstaller().update(updateInfo.newVersion, logger);
       const crcVersion = await getCrcVersion();
+      if (crcVersion) {
+        commander.setVersion(crcVersion.version);
+      }
       provider.updateDetectionChecks(getCrcDetectionChecks(crcVersion));
       provider.updateVersion(crcVersion.version);
       this.crcCliInfo.ignoreVersionUpdate = undefined;


### PR DESCRIPTION
Update crc version in daemon commander on crc update to make sure that the correct socket path is used, especially when updating to 2.62.0

Related to https://github.com/crc-org/crc-extension/pull/1158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the displayed command-line and daemon version after a successful application update.
  * Improved version detection when refreshed version information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->