### PR TITLE
chore: update js-yaml to ^4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
       "flatted": "^3.4.2",
       "follow-redirects": "^1.16.0",
       "form-data": "^4.0.6",
-      "brace-expansion@<1.1.16": "^1.1.16"
+      "brace-expansion@<1.1.16": "^1.1.16",
+      "js-yaml@<4.3.0": "^4.3.0"
     }
   },
   "extensionDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   follow-redirects: ^1.16.0
   form-data: ^4.0.6
   brace-expansion@<1.1.16: ^1.1.16
+  js-yaml@<4.3.0: ^4.3.0
 
 importers:
 
@@ -1122,8 +1123,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1873,7 +1874,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2457,7 +2458,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -2718,7 +2719,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
CVE update js-yaml to ^4.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to use a compatible version of the YAML parsing library.
  * Retained the existing dependency version constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->