### PR TITLE
chore: move registerCluster to Vm creation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -403,8 +403,7 @@ function updateProviderVersionWithPreset(provider: extensionApi.Provider, preset
 
 async function presetChanged(
   provider: extensionApi.Provider,
-  extensionContext: extensionApi.ExtensionContext,
-  telemetryLogger: extensionApi.TelemetryLogger,
+  extensionContext: extensionApi.ExtensionContext
 ): Promise<void> {
   // detect preset of CRC
   const preset = (await getPreset()) ?? 'openshift';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,9 +133,20 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
       addCommands(telemetryLogger);
     }
 
-    if (!connectionDisposable && crcStatus.status.CrcStatus === 'Running' || crcStatus.status.CrcStatus === 'Starting' || crcStatus.status.CrcStatus === 'Stopping' || crcStatus.status.CrcStatus === 'Stopped') {
+    if (
+      !connectionDisposable &&
+      (crcStatus.status.CrcStatus === 'Running' ||
+        crcStatus.status.CrcStatus === 'Starting' ||
+        crcStatus.status.CrcStatus === 'Stopping' ||
+        crcStatus.status.CrcStatus === 'Stopped')
+    ) {
       const clusterPreset = crcStatus.status.Preset ?? 'openshift';
-      registerOpenShiftLocalCluster(isPreset(clusterPreset) ? getPresetLabel(clusterPreset) : clusterPreset, provider, extensionContext, telemetryLogger);
+      registerOpenShiftLocalCluster(
+        isPreset(clusterPreset) ? getPresetLabel(clusterPreset) : clusterPreset,
+        provider,
+        extensionContext,
+        telemetryLogger,
+      );
     }
 
     // sync preset from config
@@ -403,7 +414,7 @@ function updateProviderVersionWithPreset(provider: extensionApi.Provider, preset
 
 async function presetChanged(
   provider: extensionApi.Provider,
-  extensionContext: extensionApi.ExtensionContext
+  extensionContext: extensionApi.ExtensionContext,
 ): Promise<void> {
   // detect preset of CRC
   const preset = (await getPreset()) ?? 'openshift';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,7 +149,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
     }
 
     // sync preset from config
-    await presetChanged(provider, extensionContext, telemetryLogger);
+    await presetChanged(provider, extensionContext);
   }
 
   if (crcInstaller.isAbleToInstall()) {
@@ -171,7 +171,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
           await connectToCrc();
           addCommands(telemetryLogger);
           await syncProxy(extensionContext);
-          await presetChanged(provider, extensionContext, telemetryLogger);
+          await presetChanged(provider, extensionContext);
         });
       },
     });
@@ -184,7 +184,7 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
 
   extensionContext.subscriptions.push(
     presetChangedEvent(() => {
-      presetChanged(provider, extensionContext, telemetryLogger).catch(e => console.error(String(e)));
+      presetChanged(provider, extensionContext).catch(e => console.error(String(e)));
     }),
     crcStatus.onStatusChange(e => {
       updateProviderVersionWithPreset(provider, e.Preset as Preset);
@@ -282,7 +282,7 @@ async function createCrcVm(
     const preset = (await getPreset()) ?? 'openshift';
     registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
     addCommands(telemetryLogger);
-    await presetChanged(provider, extensionContext, telemetryLogger);
+    await presetChanged(provider, extensionContext);
   }
 }
 
@@ -296,7 +296,7 @@ async function initializeCrc(
   if (hasSetupFinished) {
     await needSetup();
     await connectToCrc();
-    await presetChanged(provider, extensionContext, telemetryLogger);
+    await presetChanged(provider, extensionContext);
     addCommands(telemetryLogger);
     await syncProxy(extensionContext);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import { crcStatus } from './crc-status.js';
 import { startCrc } from './crc-start.js';
 import { needSetup, setUpCrc } from './crc-setup.js';
 import { deleteCrc } from './crc-delete.js';
-import { connectionAuditor, presetChangedEvent, saveConfig, syncProxy } from './preferences.js';
+import { connectionAuditor, isPreset, presetChangedEvent, saveConfig, syncProxy } from './preferences.js';
 import { stopCrc } from './crc-stop.js';
 import { addCommands, commandManager } from './command.js';
 import { defaultLogger } from './logger.js';
@@ -43,7 +43,7 @@ import { process } from '@podman-desktop/api';
 
 const CRC_PRESET_KEY = 'crc.crcPreset';
 
-let connectionDisposable: extensionApi.Disposable;
+let connectionDisposable: extensionApi.Disposable | undefined;
 let connectionFactoryDisposable: extensionApi.Disposable;
 
 let crcVersion: CrcVersion | undefined;
@@ -131,6 +131,11 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
     // if no need to setup we could add commands
     if (!isNeedSetup()) {
       addCommands(telemetryLogger);
+    }
+
+    if (!connectionDisposable && crcStatus.status.CrcStatus === 'Running' || crcStatus.status.CrcStatus === 'Starting' || crcStatus.status.CrcStatus === 'Stopping' || crcStatus.status.CrcStatus === 'Stopped') {
+      const clusterPreset = crcStatus.status.Preset ?? 'openshift';
+      registerOpenShiftLocalCluster(isPreset(clusterPreset) ? getPresetLabel(clusterPreset) : clusterPreset, provider, extensionContext, telemetryLogger);
     }
 
     // sync preset from config
@@ -264,6 +269,8 @@ async function createCrcVm(
     return;
   }
   if (!connectionDisposable) {
+    const preset = (await getPreset()) ?? 'openshift';
+    registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
     addCommands(telemetryLogger);
     await presetChanged(provider, extensionContext, telemetryLogger);
   }
@@ -380,6 +387,7 @@ async function handleDelete(
     deleteCommands();
     if (connectionDisposable) {
       connectionDisposable.dispose();
+      connectionDisposable = undefined;
     }
   }
 }
@@ -406,11 +414,6 @@ async function presetChanged(
   const extConfig = extensionApi.configuration.getConfiguration();
   await extConfig.update('crc.factory.preset', preset);
 
-  if (connectionDisposable) {
-    connectionDisposable.dispose();
-    connectionDisposable = undefined;
-  }
-
   if (preset === 'podman') {
     // do nothing
     await extensionApi.window.showInformationMessage(
@@ -420,11 +423,5 @@ async function presetChanged(
 
     // podman connection
     registerPodmanConnection(provider, extensionContext);
-  } else if (preset === 'openshift' || preset === 'microshift') {
-    // Only register connection if a cluster actually exists (not 'No Cluster', 'Unknown', or 'Need Setup')
-    const currentStatus = crcStatus.status.CrcStatus;
-    if (currentStatus !== 'No Cluster' && currentStatus !== 'Unknown' && currentStatus !== 'Need Setup') {
-      registerOpenShiftLocalCluster(getPresetLabel(preset), provider, extensionContext, telemetryLogger);
-    }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,11 +134,10 @@ async function _activate(extensionContext: extensionApi.ExtensionContext): Promi
     }
 
     if (
-      !connectionDisposable &&
-      (crcStatus.status.CrcStatus === 'Running' ||
-        crcStatus.status.CrcStatus === 'Starting' ||
-        crcStatus.status.CrcStatus === 'Stopping' ||
-        crcStatus.status.CrcStatus === 'Stopped')
+      crcStatus.status.CrcStatus === 'Running' ||
+      crcStatus.status.CrcStatus === 'Starting' ||
+      crcStatus.status.CrcStatus === 'Stopping' ||
+      crcStatus.status.CrcStatus === 'Stopped'
     ) {
       const clusterPreset = crcStatus.status.Preset ?? 'openshift';
       registerOpenShiftLocalCluster(

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -74,7 +74,7 @@ async function handleProxyChange(proxy?: extensionApi.ProxySettings): Promise<vo
   }
 }
 
-function isPreset(data: string): data is Preset {
+export function isPreset(data: string): data is Preset {
   if (data === 'microshift' || data === 'openshift' || data === 'podman') {
     return true;
   } else {


### PR DESCRIPTION
When creating a new cluster after deleting an old one without changing the preset, the new cluster won't show up in the resources page (reproducible on v2.3.0).

`registerOpenShiftLocalCluster` was called only in `presetChanged`, and `presetChanged` was called in `createCrcVm` only when there was no `connectionDisposable`. However, `handleDelete` only disposed of the `connectionDisposable` and didn't set it to undefined, so when calling `createCrcVm` after deleting an old cluster, the new one wasn't registered since there was already `connectionDisposable`.

In addition, changing presets should not register new clusters, especially if there is an existing one, since the preset of a cluster cannot be changed without deleting it and creating a new one

Fixes https://github.com/crc-org/crc-extension/issues/296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift Local connection startup by automatically using the detected preset as the default during CRC lifecycle transitions.
  * Preserved the selected preset (and the appropriate cluster label when applicable) when creating and updating OpenShift Local connections.
  * Enhanced connection deletion cleanup by fully clearing the active connection state.
  * Refined preset-change behavior to reduce unnecessary connection resets, with explicit handling focused on the Podman preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->