### PR TITLE
fix: use the same scopes to allow extensions sharing auth sessions

### DIFF
--- a/src/crc-start.spec.ts
+++ b/src/crc-start.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type * as extensionApi from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { AccountManagementClient } from '@redhat-developer/rhaccm-client';
 import { beforeEach, expect, test, vi } from 'vitest';
 import * as crcCli from './crc-cli.js';
 import * as crcSetup from './crc-setup.js';
-import { startCrc } from './crc-start.js';
+import { AuthenticationScopes, startCrc } from './crc-start.js';
 import * as logProvider from './log-provider.js';
 import * as daemon from './daemon-commander.js';
 import type { StartInfo } from './types.js';
@@ -31,9 +32,17 @@ vi.mock('@podman-desktop/api', async () => {
     EventEmitter: vi.fn(),
     window: {
       showErrorMessage: vi.fn(),
+      showInputBox: vi.fn(),
+    },
+    authentication: {
+      getSession: vi.fn(),
     },
   };
 });
+
+vi.mock('@redhat-developer/rhaccm-client', () => ({
+  AccountManagementClient: vi.fn(),
+}));
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -132,4 +141,49 @@ test('startCrc throws on general error', async () => {
   ).rejects.toThrow('connection timeout');
 
   expect(updateStatus).toHaveBeenCalledWith('stopped');
+});
+
+test('obtains pull secret from REST service using SSO token and starts successfully', async () => {
+  const accessToken = 'sso-access-token';
+  const pullSecretCfg = {
+    auths: {
+      'registry.redhat.io': { auth: 'dXNlcjpwYXNz' },
+    },
+  };
+  const postApiAccountsMgmtV1AccessToken = vi.fn().mockResolvedValue(pullSecretCfg);
+  vi.mocked(AccountManagementClient).mockImplementation(function AccountManagementClientMock() {
+    return {
+      default: { postApiAccountsMgmtV1AccessToken },
+    };
+  } as unknown as typeof AccountManagementClient);
+  vi.spyOn(crcCli, 'execPromise').mockResolvedValue('');
+  vi.spyOn(logProvider.crcLogProvider, 'startSendingLogs').mockResolvedValue();
+  vi.spyOn(daemon.commander, 'start')
+    .mockRejectedValueOnce(new Error('Failed to ask for pull secret'))
+    .mockResolvedValueOnce({ Status: 'Running' } as unknown as StartInfo);
+  const pullSecretStore = vi.spyOn(daemon.commander, 'pullSecretStore').mockResolvedValue('');
+  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue({
+    accessToken,
+  } as extensionApi.AuthenticationSession);
+  const updateStatus = vi.fn();
+
+  await startCrc(
+    { updateStatus } as unknown as extensionApi.Provider,
+    {} as extensionApi.Logger,
+    { logUsage: vi.fn() } as unknown as extensionApi.TelemetryLogger,
+  );
+
+  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith(
+    'redhat.authentication-provider',
+    AuthenticationScopes,
+    { createIfNone: true },
+  );
+  expect(AccountManagementClient).toHaveBeenCalledWith({
+    BASE: 'https://api.openshift.com',
+    TOKEN: accessToken,
+  });
+  expect(postApiAccountsMgmtV1AccessToken).toHaveBeenCalledOnce();
+  expect(pullSecretStore).toHaveBeenCalledWith(JSON.stringify(pullSecretCfg));
+  expect(extensionApi.window.showInputBox).not.toHaveBeenCalled();
+  expect(updateStatus).toHaveBeenCalledWith('started');
 });

--- a/src/crc-start.ts
+++ b/src/crc-start.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,11 @@ interface Auths {
 }
 
 const missingPullSecret = 'Failed to ask for pull secret';
+
+export const AuthenticationScopes = [
+  'api.iam.registry_service_accounts', // scope that gives access to hydra service accounts API
+  'api.console', // scope that gives access to console.redhat.com APIs
+];
 
 export async function startCrc(
   provider: extensionApi.Provider,
@@ -97,10 +102,7 @@ async function askAndStorePullSecret(logger: extensionApi.Logger): Promise<boole
   let pullSecret: string;
   const authSession: extensionApi.AuthenticationSession | undefined = await extensionApi.authentication.getSession(
     'redhat.authentication-provider',
-    [
-      'api.iam.registry_service_accounts', //scope that gives access to hydra service accounts API
-      'api.console', // scope that gives access to console.redhat.com APIs
-    ], // adds claim to accessToken that used to render account label
+    AuthenticationScopes, // adds claim to accessToken that used to render account label
     { createIfNone: true }, // will request to login in browser if session does not exists
   );
   if (authSession) {

--- a/src/crc-start.ts
+++ b/src/crc-start.ts
@@ -100,7 +100,6 @@ async function askAndStorePullSecret(logger: extensionApi.Logger): Promise<boole
     [
       'api.iam.registry_service_accounts', //scope that gives access to hydra service accounts API
       'api.console', // scope that gives access to console.redhat.com APIs
-      'id.username',
     ], // adds claim to accessToken that used to render account label
     { createIfNone: true }, // will request to login in browser if session does not exists
   );


### PR DESCRIPTION
Fix is related to

https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/773

All extension using the same scopes can request to share existing authentication session instead of triggering full sign in workflow in external browser.

The removed scope is used by default in SSO, so this extension won't be affected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the authentication/session request to request only the required access scopes, improving the reliability of pull-secret setup.
  * Improved the SSO-based pull-secret flow to avoid showing a manual input prompt when an SSO token is used.
* **Tests**
  * Added/updated automated coverage for the SSO pull-secret handling path and the associated session/authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->