### PR TITLE
fix(e2e): remove unnecessary workaround for tests-playwright version

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -88,34 +88,7 @@ jobs:
           pnpm install
           pnpm test:e2e:build
       
-      - name: Ensure getting current HEAD version of the test framework (Ubuntu/MacOS)
-        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'macos-26' 
-        working-directory: ./crc-extension
-        run: |
-          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
-          version=$(npm view @podman-desktop/tests-playwright@next version)
-          echo "Version of @podman-desktop/tests-playwright to be used: $version"
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
-        shell: bash
 
-      - name: Ensure getting current HEAD version of the test framework (Windows)
-        if: matrix.os == 'windows-2025' 
-        working-directory: ./crc-extension
-        run: |
-          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
-          # Install scoop installer
-          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-          scoop --version
-          # Install jq using scoop
-          scoop install jq
-          # Fetch the version of the npm package
-          $version = npm view @podman-desktop/tests-playwright@next version
-          Write-Host "Version of @podman-desktop/tests-playwright to be used: $version"
-          # Update package.json using jq
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp
-          # Replace the old package.json with the updated one
-          Move-Item -Path package.json_tmp -Destination package.json -Force
-        shell: pwsh
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         if: matrix.os == 'ubuntu-24.04'
@@ -127,7 +100,7 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./crc-extension
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # build crc extension
           podman build -t openshift_local_image . -f ./oci/Containerfile.multistage
           CONTAINER_ID_CRC=$(podman create localhost/openshift_local_image --entrypoint "")
@@ -150,7 +123,7 @@ jobs:
         shell: bash
         working-directory: ./crc-extension
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # -- following https://github.com/crc-org/crc-extension/blob/main/oci/Containerfile.multistage --
           # build extension
           pnpm build
@@ -165,7 +138,7 @@ jobs:
         working-directory: ./crc-extension
         shell: pwsh
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # -- following https://github.com/crc-org/crc-extension/blob/main/oci/Containerfile.multistage --
           # build extension
           pnpm build

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -156,34 +156,7 @@ jobs:
           pnpm install
           pnpm test:e2e:build
       
-      - name: Ensure getting current HEAD version of the test framework (Ubuntu/MacOS)
-        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'macos-26' 
-        working-directory: ./crc-extension
-        run: |
-          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
-          version=$(npm view @podman-desktop/tests-playwright@next version)
-          echo "Version of @podman-desktop/tests-playwright to be used: $version"
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
-        shell: bash
 
-      - name: Ensure getting current HEAD version of the test framework (Windows)
-        if: matrix.os == 'windows-2025' 
-        working-directory: ./crc-extension
-        run: |
-          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
-          # Install scoop installer
-          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-          scoop --version
-          # Install jq using scoop
-          scoop install jq
-          # Fetch the version of the npm package
-          $version = npm view @podman-desktop/tests-playwright@next version
-          Write-Host "Version of @podman-desktop/tests-playwright to be used: $version"
-          # Update package.json using jq
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp
-          # Replace the old package.json with the updated one
-          Move-Item -Path package.json_tmp -Destination package.json -Force
-        shell: pwsh
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         if: matrix.os == 'ubuntu-24.04'
@@ -195,7 +168,7 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./crc-extension
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # build crc extension
           podman build -t openshift_local_image . -f ./oci/Containerfile.multistage
           CONTAINER_ID_CRC=$(podman create localhost/openshift_local_image --entrypoint "")
@@ -218,7 +191,7 @@ jobs:
         shell: bash
         working-directory: ./crc-extension
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # -- following https://github.com/crc-org/crc-extension/blob/main/oci/Containerfile.multistage --
           # build extension
           pnpm build
@@ -233,7 +206,7 @@ jobs:
         working-directory: ./crc-extension
         shell: pwsh
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # -- following https://github.com/crc-org/crc-extension/blob/main/oci/Containerfile.multistage --
           # build extension
           pnpm build
@@ -249,7 +222,7 @@ jobs:
         working-directory: ./sso-extension
         shell: bash
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # -- following https://github.com/redhat-developer/podman-desktop-redhat-account-ext/blob/main/Containerfile --
           # build extension
           pnpm build
@@ -262,7 +235,7 @@ jobs:
         working-directory: ./sso-extension
         shell: pwsh
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           # -- following https://github.com/redhat-developer/podman-desktop-redhat-account-ext/blob/main/Containerfile --
           # build extension
           pnpm build


### PR DESCRIPTION
## Description

The step was dynamically replacing the `@podman-desktop/tests-playwright` version with the latest @next release before running pnpm install. With pnpm v11 minimumReleaseAge defaulting to 1440 minutes, this breaks CI when a @next version was published within the last 24 hours.

The workaround referenced https://github.com/containers/podman-desktop-extension-bootc/issues/712 and is no longer needed.

## Related issues

Required for 
- https://github.com/crc-org/crc-extension/pull/1187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the consistency and reliability of automated end-to-end validation across supported platforms.
  * Standardized dependency installation to use locked versions, helping ensure repeatable build and test results.
  * Removed automatic use of pre-release testing packages during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->